### PR TITLE
Validate factorial input in interactive mode

### DIFF
--- a/cli/interactive_mode.py
+++ b/cli/interactive_mode.py
@@ -106,7 +106,11 @@ def run_interactive_mode(plugin_manager, operations_metadata: Dict) -> None:
             try:
                 if arg_name == 'n' and op_name == 'factorial':
                     # Factorial needs integer
-                    arg_values.append(int(float(arg_parts[i])))
+                    value = float(arg_parts[i])
+                    if not value.is_integer():
+                        print(f"Error: Invalid argument '{arg_parts[i]}' for {arg_name}. Expected an integer.")
+                        return None
+                    arg_values.append(int(value))
                 else:
                     arg_values.append(float(arg_parts[i]))
             except ValueError:

--- a/tests/test_interactive_mode.py
+++ b/tests/test_interactive_mode.py
@@ -1,0 +1,20 @@
+import subprocess
+import sys
+from pathlib import Path
+
+def run_cli(commands: str) -> str:
+    """Run math_cli.py in interactive mode with the provided commands."""
+    repo_root = Path(__file__).resolve().parent.parent
+    result = subprocess.run(
+        [sys.executable, "math_cli.py", "-i"],
+        input=commands.encode(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=repo_root,
+        check=False,
+    )
+    return result.stdout.decode()
+
+def test_factorial_requires_integer():
+    output = run_cli("factorial 5.5\nexit\n")
+    assert "Invalid argument '5.5' for n. Expected an integer." in output


### PR DESCRIPTION
## Summary
- ensure factorial input is an integer before execution
- add regression test for interactive factorial input

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a15f2aee4c83328b3c694347ee2142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved input validation in interactive CLI: the factorial command now requires an integer and provides a clear error message when given non-integer values (e.g., 5.5).
- Bug Fixes
  - Prevents unintended truncation of non-integer inputs for factorial, ensuring accurate and predictable behavior.
- Tests
  - Added automated test covering interactive mode to verify the integer-only requirement and error messaging for the factorial command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->