### PR TITLE
Skip template and private plugin modules

### DIFF
--- a/core/plugin_manager.py
+++ b/core/plugin_manager.py
@@ -52,6 +52,10 @@ class PluginManager:
             module = importlib.import_module(module_name)
             for _, submodule_name, ispkg in pkgutil.iter_modules(module.__path__, module.__name__ + '.'):
                 if not ispkg:  # Only process modules, not packages
+                    base_name = submodule_name.rsplit('.', 1)[-1]
+                    # Skip templates and private modules
+                    if base_name.endswith('plugin_template') or base_name.startswith('_'):
+                        continue
                     try:
                         submodule = importlib.import_module(submodule_name)
                         self._register_operations_from_module(submodule)


### PR DESCRIPTION
## Summary
- Skip importing plugin submodules whose names end with `plugin_template` or start with `_`, preventing example plugins from registering

## Testing
- `python - <<'PY'
from core.plugin_manager import PluginManager
pm = PluginManager()
pm.discover_plugins()
print('operations:', sorted(pm.operations.keys()))
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a160f86bac8332bb1bfb54a2702360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin discovery to skip template and private modules, preventing accidental loading and reducing false import errors.
  * Results in more reliable startup and a cleaner, accurate list of available plugins without changing public APIs or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->