### PR TITLE
docs: add CLI startup and history diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,16 +304,24 @@ options:
 
 ## Code Structure Diagrams
 
-To better understand the structure and flow of the Math CLI application, refer to these diagrams:
+To better understand the structure and flow of the Math CLI application, refer to these diagrams.
 
+### Overview
 - [Class Diagram (UML)](docs/class-diagram.md) - Shows the main classes and their relationships
 - [Package Structure](docs/package-structure.md) - Shows how the code is organized into packages and modules
-- [Plugin System Flowchart](docs/plugin-system.md) - Explains how the plugin system works
+
+### Application Flow
+- [CLI Startup Flowchart](docs/cli-startup.md) - Shows how command-line arguments are processed and the run mode is selected
 - [Command Execution Sequence](docs/command-execution.md) - Details how commands are processed
 - [Interactive Mode State Diagram](docs/interactive-mode.md) - Shows the state transitions in interactive mode
-- [User Interaction Diagram](docs/user-interaction.md) - Shows how users interact with the application
+- [History Management Flow](docs/history-flow.md) - Describes how command history is stored and retrieved
+
+### Plugin Architecture
+- [Plugin System Flowchart](docs/plugin-system.md) - Explains how the plugin system works
 - [Plugin Loading Process](docs/plugin-loading.md) - Details how plugins are discovered and loaded
 
+### User Interaction
+- [User Interaction Diagram](docs/user-interaction.md) - Shows how users interact with the application
 ## Contributing
 
 Contributions to Math CLI are welcome! Here are some ways to contribute:

--- a/docs/cli-startup.md
+++ b/docs/cli-startup.md
@@ -1,0 +1,25 @@
+## 8. CLI Startup Flowchart
+
+This flowchart shows how the application processes command-line arguments and determines how to run.
+
+```mermaid
+flowchart TD
+    A[Start Math CLI] --> B[Parse command-line arguments]
+    B --> C{--list-plugins?}
+    C -- Yes --> D[List available plugins]
+    C -- No --> E{--interactive?}
+    E -- Yes --> F[Launch interactive session]
+    E -- No --> G[Execute single operation]
+    D --> H[End]
+    F --> H
+    G --> H
+```
+
+### Startup Steps
+
+1. **Start Math CLI** – The application begins execution.
+2. **Parse command-line arguments** – The CLI reads options and parameters.
+3. **List plugins** – If `--list-plugins` is supplied, available operations are shown and the program exits.
+4. **Interactive mode** – If `--interactive` is provided, the interactive REPL starts.
+5. **Execute single operation** – Otherwise the specified operation is run once and the result is printed.
+6. **End** – The program terminates after completing the selected action.

--- a/docs/history-flow.md
+++ b/docs/history-flow.md
@@ -1,0 +1,26 @@
+## 9. History Management Flow
+
+This diagram illustrates how the interactive mode records and retrieves command history.
+
+```mermaid
+flowchart TD
+    A[Operation executed] --> B[Add entry to HistoryManager]
+    B --> C[History stored]
+
+    D[User enters 'history' command] --> E{Argument?}
+    E -- none --> F[Return all entries]
+    E -- number --> G[Return specific entry]
+    E -- "clear" --> H[Clear all history]
+    F --> I[Display to user]
+    G --> I
+    H --> I
+```
+
+### History Actions
+
+1. **Operation executed** – After each successful command, the result is recorded.
+2. **Add entry** – The command and result are stored in the HistoryManager.
+3. **History command** – When the user types `history`, the system checks for additional arguments.
+4. **Return all entries** – Without arguments, the full history is displayed.
+5. **Return specific entry** – With a number, a particular entry is shown.
+6. **Clear all history** – The `history clear` command removes all stored entries.


### PR DESCRIPTION
## Summary
- add flowchart showing command-line startup choices
- document history manager interactions
- reorganize README diagram section with links to new docs

## Testing
- `python tests/test_history.py` *(ran via manual script)*


------
https://chatgpt.com/codex/tasks/task_e_68a16f772c7883329dafd26187fbcb66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized Code Structure Diagrams into Overview, Application Flow, Plugin Architecture, and User Interaction sections.
  * Added new docs: CLI Startup flow and History Management Flow, including diagrams and step-by-step guides.
  * Adjusted diagram placement under new sections; expanded Application Flow items.
  * Expanded Contributing guidance with clear steps and requirements; added dedicated GitHub link in footer.
  * Minor wording/style tweak to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->